### PR TITLE
Intruduced basic CMake configuration

### DIFF
--- a/BoostTupleConfig.cmake
+++ b/BoostTupleConfig.cmake
@@ -1,0 +1,11 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(CMakeFindDependencyMacro)
+find_dependency(BoostConfig 1.66)
+find_dependency(BoostCore 1.66)
+find_dependency(BoostStaticAssert 1.66)
+find_dependency(BoostTypeTraits 1.66)
+find_dependency(BoostUtility 1.66)
+include("${CMAKE_CURRENT_LIST_DIR}/BoostTupleTargets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Copyright 2018 Thomas Jandecka
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+
+project(BoostTuple VERSION 1.66 LANGUAGES CXX)
+
+add_library(tuple INTERFACE)
+
+target_include_directories(tuple INTERFACE 
+    $<BUILD_INTERFACE:${BoostTuple_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${BoostTuple_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    )
+
+find_package(BoostConfig 1.66 REQUIRED)
+find_package(BoostCore 1.66 REQUIRED)
+find_package(BoostStaticAssert 1.66 REQUIRED)
+find_package(BoostTypeTraits 1.66 REQUIRED)
+find_package(BoostUtility 1.66 REQUIRED)
+
+target_link_libraries(tuple
+    INTERFACE
+        Boost::config
+        Boost::core
+        Boost::static_assert
+        Boost::type_traits
+        Boost::utility
+    )
+
+install(EXPORT tuple-targets
+    FILE BoostTupleTargets.cmake
+    NAMESPACE Boost::
+    DESTINATION lib/cmake/boost
+    )
+
+install(TARGETS tuple EXPORT tuple-targets
+    INCLUDES DESTINATION include
+    )
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("BoostTupleConfigVersion.cmake"
+    VERSION ${BoostTuple_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+install(
+    FILES
+        "BoostTupleConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/BoostTupleConfigVersion.cmake"
+    DESTINATION
+        lib/cmake/boost
+    )
+install(DIRECTORY include/ DESTINATION include)
+
+add_library(Boost::tuple ALIAS tuple)


### PR DESCRIPTION
Expresses Boost::tuple as an `INTERFACE` library in CMake.
- use via `add_subdirectory` 
- use via `find_package(BoostTuple 1.66)` if previously installed. This is achieved via the following install:
```
$INSTALL_PREFIX
├── include
│   └── boost
│       └── tuple
│           ├── detail
│           │   └── tuple_basic.hpp
│           ├── tuple_comparison.hpp
│           ├── tuple.hpp
│           └── tuple_io.hpp
└── lib
    └── cmake
        └── boost
            ├── BoostTupleConfig.cmake
            ├── BoostTupleConfigVersion.cmake
            └── BoostTupleTargets.cmake

7 directories, 7 files
```
- tests are __not__ included in the build